### PR TITLE
Fixes #39 - Add ros_packages to ros_install role. 

### DIFF
--- a/ansible/roles/ros_install/tasks/main.yml
+++ b/ansible/roles/ros_install/tasks/main.yml
@@ -40,5 +40,16 @@
     - python-wstool
     - python-rosinstall
 
+- name: Aggregate specific ROS packages names
+  when: ros_packages is defined and ros_packages != ""
+  action: shell echo "ros-{{ros_release}}-{{item}}"
+  with_items: ros_packages
+  register: full_ros_packages_names
+
+- name: Install specific ROS packages
+  when: full_ros_packages_names is defined and full_ros_packages_names != ""
+  apt: name={{item.stdout}}
+  with_items: full_ros_packages_names.results
+
 - name: rosdep init
   command: rosdep init creates=/etc/ros/rosdep/sources.list.d/20-default.list


### PR DESCRIPTION
Not sure why I had to do the loop + temp variable with echo...

If using 

```
- name: Install specific ROS packages
  when: full_ros_packages_names is defined and full_ros_packages_names != ""
  apt: name="ros-{{ros_release}}-{{item}}"
  with_items: ros_packages
```

vagrant tries to run: `apt-get install ros-hydro-first-package second-package` (prefix applied to first package only!!

The actual list of additional packages will be added to #41 
