### PR TITLE
Fixes #109 - cpp coverage

### DIFF
--- a/ansible/roles/ci/unit_tests/tasks/main.yml
+++ b/ansible/roles/ci/unit_tests/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Playbook for unit tests
 
-- name: catkin run tests
+- name: catkin run tests -DCOVERAGE=ON
   shell: bash -c "source {{ros_workspace}}/devel/setup.bash && catkin_make run_tests"
     chdir={{ros_workspace}}

--- a/ansible/roles/ci/unit_tests/tasks/main.yml
+++ b/ansible/roles/ci/unit_tests/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Playbook for unit tests
 
-- name: catkin run tests -DCOVERAGE=ON
-  shell: bash -c "source {{ros_workspace}}/devel/setup.bash && catkin_make run_tests"
+- name: catkin run tests
+  shell: bash -c "source {{ros_workspace}}/devel/setup.bash && catkin_make run_tests -DCOVERAGE=ON"
     chdir={{ros_workspace}}


### PR DESCRIPTION
Most of the work needs to be done per package. This makes it possible to check for a flag in the CMake in order to compile with coverage options:

```cmake
set(COVERAGE "OFF" CACHE STRING "Enable coverage generation.")
message(STATUS "Using COVERAGE: ${COVERAGE}")
if("${COVERAGE}" STREQUAL "ON")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
endif()
```