### PR TITLE
Missing rosdep update

### DIFF
--- a/ansible/roles/ros_install/tasks/main.yml
+++ b/ansible/roles/ros_install/tasks/main.yml
@@ -53,3 +53,6 @@
 
 - name: rosdep init
   command: rosdep init creates=/etc/ros/rosdep/sources.list.d/20-default.list
+  
+- name: Update dependencies
+  shell: bash -c "rosdep update -y"


### PR DESCRIPTION
In this build, it doesn't find the (newly added) rosdep: https://app.shippable.com/builds/558a995796f1b50e00d4d3f7