### PR TITLE
Install ssh by default

### DIFF
--- a/ansible/roles/ros_install/tasks/main.yml
+++ b/ansible/roles/ros_install/tasks/main.yml
@@ -39,6 +39,7 @@
     - "{{ ros_base_package }}"
     - python-wstool
     - python-rosinstall
+    - ssh
 
 - name: Aggregate specific ROS packages names
   when: ros_packages is defined and ros_packages != ""


### PR DESCRIPTION
It could have been done in another place so as not to hijack the "install ros" task. Seems harmless to me to do it that way though.