### PR TITLE
New role to build debs and push them to an aptly repo

### DIFF
--- a/ansible/docker_site.yml
+++ b/ansible/docker_site.yml
@@ -53,6 +53,7 @@
     - {role: ci/code_style_check/cpp, when: run_build, tags: ["cpp_code_style_check", "code_style_check"]}
     - {role: ci/deploy/complete_deb_check, when: run_build, tags: ["complete_deb_check"]}
     - {role: ci/deploy/check_deb_make, when: run_build, tags: ["check_deb_make", "complete_deb_check"]}
+    - {role: ci/deploy/upload_debs, when: run_build, tags: ["upload_debs"]}
     - {role: ci/servers/travis/finalize, when: run_build, tags: ["travis"]}
     - {role: ci/servers/shippable/finalize, when: run_build, tags: ["shippable"]}
     - {role: ci/servers/circle/finalize, when: run_build, tags: ["circle"]}

--- a/ansible/roles/ci/deploy/build_debs/meta/main.yml
+++ b/ansible/roles/ci/deploy/build_debs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: packages }

--- a/ansible/roles/ci/deploy/build_debs/meta/main.yml
+++ b/ansible/roles/ci/deploy/build_debs/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: packages }
+  - { role: ci/common/packages }

--- a/ansible/roles/ci/deploy/build_debs/tasks/main.yml
+++ b/ansible/roles/ci/deploy/build_debs/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Playbook for building deb files
+
+- name: Clean debian packages folders in case of the cached build
+  shell: bash -c "rm -rf ./debian && rm -rf ./obj-x86_64-linux-gnu"
+    chdir={{repo_sources_path}}/{{item.path}}
+  with_items: "{{repo_packages_list|default([])}}"
+  ignore_errors: True
+
+- name: Clean debian packages from repository directory
+  shell: bash -c "find . -name '*.deb' -type f -delete"
+    chdir={{repo_sources_path}}
+  ignore_errors: True
+
+- name: Add line to rosdep package cache
+  lineinfile: dest=/etc/ros/rosdep/sources.list.d/20-default.list line="yaml file://{{repo_sources_path}}/local_custom_rosdep.yaml"
+
+- name: Create empty file or clean existing one
+  shell: bash -c "cat /dev/null > {{repo_sources_path}}/local_custom_rosdep.yaml"
+
+- name: Append repository packages to rosdep ignore list
+  shell: echo "{{item.name}}:{{' '}}{ubuntu:[]}" >> {{repo_sources_path}}/local_custom_rosdep.yaml
+  with_items: "{{repo_packages_list|default([])}}"
+  when: complete_debian_packages_check
+
+- name: Append workspace packages to rosdep ignore list
+  shell: echo "{{item.name}}:{{' '}}{ubuntu:[]}" >> {{repo_sources_path}}/local_custom_rosdep.yaml
+  with_items: "{{workspace_packages_list|default([])}}"
+  when: not complete_debian_packages_check
+
+- name: Update rosdep
+  shell: bash -c "rosdep update"
+
+- name: Generate ROS debian package files
+  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && bloom-generate rosdebian --os-name ubuntu --os-version trusty --ros-distro {{ros_release}}"
+    chdir={{repo_sources_path}}/{{item.path}}
+  with_items:
+    - "{{repo_packages_list|default([])}}"

--- a/ansible/roles/ci/deploy/build_debs/tasks/main.yml
+++ b/ansible/roles/ci/deploy/build_debs/tasks/main.yml
@@ -28,6 +28,9 @@
   with_items: "{{workspace_packages_list|default([])}}"
   when: not complete_debian_packages_check
 
+- name: display local rosdep
+  shell: cat {{repo_sources_path}}/local_custom_rosdep.yaml
+
 - name: Update rosdep
   shell: bash -c "rosdep update"
 

--- a/ansible/roles/ci/deploy/check_deb_make/meta/main.yml
+++ b/ansible/roles/ci/deploy/check_deb_make/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: build_debs }

--- a/ansible/roles/ci/deploy/check_deb_make/tasks/main.yml
+++ b/ansible/roles/ci/deploy/check_deb_make/tasks/main.yml
@@ -1,42 +1,6 @@
 ---
 # Playbook for Deb files check
 
-- name: Clean debian packages folders in case of the cached build
-  shell: bash -c "rm -rf ./debian && rm -rf ./obj-x86_64-linux-gnu"
-    chdir={{repo_sources_path}}/{{item.path}}
-  with_items: "{{repo_packages_list|default([])}}"
-  ignore_errors: True
-
-- name: Clean debian packages from repository directory
-  shell: bash -c "find . -name '*.deb' -type f -delete"
-    chdir={{repo_sources_path}}
-  ignore_errors: True
-
-- name: Add line to rosdep package cache
-  lineinfile: dest=/etc/ros/rosdep/sources.list.d/20-default.list line="yaml file://{{repo_sources_path}}/local_custom_rosdep.yaml"
-
-- name: Create empty file or clean existing one
-  shell: bash -c "cat /dev/null > {{repo_sources_path}}/local_custom_rosdep.yaml"
-
-- name: Append repository packages to rosdep ignore list
-  shell: echo "{{item.name}}:{{' '}}{ubuntu:[]}" >> {{repo_sources_path}}/local_custom_rosdep.yaml
-  with_items: "{{repo_packages_list|default([])}}"
-  when: complete_debian_packages_check
-
-- name: Append workspace packages to rosdep ignore list
-  shell: echo "{{item.name}}:{{' '}}{ubuntu:[]}" >> {{repo_sources_path}}/local_custom_rosdep.yaml
-  with_items: "{{workspace_packages_list|default([])}}"
-  when: not complete_debian_packages_check
-
-- name: Update rosdep
-  shell: bash -c "rosdep update"
-
-- name: Generate ROS debian package files
-  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && bloom-generate rosdebian --os-name ubuntu --os-version trusty --ros-distro {{ros_release}}"
-    chdir={{repo_sources_path}}/{{item.path}}
-  with_items:
-    - "{{repo_packages_list|default([])}}"
-
 # Redundant loop count to make sure that even complex dependencies scenario is resolved
 # mv command will fail in case if package is already installed for this case there is ignore_errors
 - name: Create and install debian packages recursively in order to fix local dependencies

--- a/ansible/roles/ci/deploy/upload_debs/defaults/main.yml
+++ b/ansible/roles/ci/deploy/upload_debs/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Defaults aptly url
+
+aptly_url: http://10.10.10.62:8080

--- a/ansible/roles/ci/deploy/upload_debs/meta/main.yml
+++ b/ansible/roles/ci/deploy/upload_debs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: check_deb_make }

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -13,19 +13,19 @@
   register: deb_paths
 
 - name: Cleanup deb name first_path
-  shell: dpkg --info {{item}} | grep Package
+  shell: dpkg --info {{item.stdout}} | grep Package
   with_items:
     - "{{ deb_paths }}"
   register: deb_names_first_path
 
 - name: Finish deb name cleanup
-  shell: echo {{ item.replace('Package ', '')}}
+  shell: echo {{ item.stdout.replace('Package ', '')}}
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+  shell: curl -X POST -F file=@{{ item.0.stdout }} http://10.10.10.62:8080/api/files/{{ item.1.stdout }}
   with_together:
     - "{{ deb_paths }}"
     - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+# Playbook for uploading deb files to an apt repo
+
+- name: List all present deb packages
+  shell: ls *.deb
+  chdir={{repo_sources_path}}

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -24,7 +24,7 @@
     installed_packages_names_stdout_lines: "{{installed_packages_names.stdout_lines}}"
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+  shell: "curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}"
     chdir={{repo_sources_path}}
   with_together:
     - "{{ deb_paths_stdout_lines|default([]) }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -24,7 +24,7 @@
     installed_packages_names_stdout_lines: "{{installed_packages_names.stdout_lines}}"
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+  shell: curl -X POST -F file=@{{ item.0 }} {{aptly_url}}/api/files/{{ item.1 }}
     chdir={{repo_sources_path}}
   with_together:
     - "{{ deb_paths_stdout_lines|default([]) }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -24,7 +24,7 @@
     installed_packages_names_stdout_lines: "{{installed_packages_names.stdout_lines}}"
 
 - name: Send files to aptly repository
-  shell: "curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}"
+  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
     chdir={{repo_sources_path}}
   with_together:
     - "{{ deb_paths_stdout_lines|default([]) }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,5 +6,5 @@
     chdir={{repo_sources_path}}
 
 - name: Send files to aptly repository
-  shell: find . -name '*.deb' | xargs curl -X POST -F file=@{} http://10.10.10.62:8080/api/files/{}
+  shell: curl -X POST -F file=@ros-indigo-sr-benchmarking_0.0.0-0trusty_amd64.deb http://10.10.10.62:8080/api/files/ros-indigo-sr-benchmarking
     chdir={{repo_sources_path}}

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -5,8 +5,23 @@
   shell: bash -c "ls *.deb"
     chdir={{repo_sources_path}}
 
-- name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/`dpkg --info {{item}} | grep Package | sed 's/Package: //' `
+- name: Save deb paths
+  shell: echo {{item}}
     chdir={{repo_sources_path}}
   with_fileglob:
     - "{{repo_sources_path}}/*.deb"
+  register: deb_paths
+
+- name: Cleanup deb name
+  shell: dpkg --info {{item}} | grep Package | sed 's/Package: //'
+    chdir={{repo_sources_path}}
+  with_items:
+    - "{{ deb_paths }}"
+  register: deb_names
+
+- name: Send files to aptly repository
+  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+    chdir={{repo_sources_path}}
+  with_together:
+    - "{{ deb_paths }}"
+    - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -13,7 +13,7 @@
   register: deb_paths
 
 - name: Cleanup deb name
-  shell: dpkg --info {{item}} | grep Package | sed 's/Package: //'
+  shell: bash -c "dpkg --info {{item}} | grep Package | sed 's/Package: //'"
     chdir={{repo_sources_path}}
   with_items:
     - "{{ deb_paths }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,7 +6,7 @@
     chdir={{repo_sources_path}}
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/{{item}}.split('/')[-1].split('_')[0]
+  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/`dpkg --info {{item}} | grep Package | sed 's/Package: //' `
     chdir={{repo_sources_path}}
   with_fileglob:
     - "{{repo_sources_path}}/*.deb"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -19,7 +19,13 @@
   register: deb_names_first_path
 
 - name: Finish deb name cleanup
-  replace: {{ item.replace('Package: ', '')}}
+  shell: echo {{ item.replace('Package: ', '')}}
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names
+
+- name: Send files to aptly repository
+  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+  with_together:
+    - "{{ deb_paths }}"
+    - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -12,16 +12,20 @@
     - "{{repo_sources_path}}/*.deb"
   register: deb_paths
 
-- name: Cleanup deb name
-  shell: bash -c "dpkg --info {{item}} | grep Package | sed 's/Package: //'"
-    chdir={{repo_sources_path}}
+- name: Cleanup deb name first_path
+  shell: bash -c "dpkg --info {{item}} | grep Package
   with_items:
     - "{{ deb_paths }}"
+  register: deb_names_first_path
+
+- name: Finish deb name cleanup
+  replace: {{ item.replace('Package: ', '')}}
+  with_items:
+    - "{{ deb_names_first_path }}"
   register: deb_names
 
 - name: Send files to aptly repository
   shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
-    chdir={{repo_sources_path}}
   with_together:
     - "{{ deb_paths }}"
     - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,7 +6,7 @@
     chdir={{repo_sources_path}}
 
 - name: Save deb paths
-  shell: bash -c "find . -name '*.deb' -print0
+  shell: bash -c "find . -name '*.deb' -print0"
     chdir={{repo_sources_path}}
   register: deb_paths
 

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -4,3 +4,7 @@
 - name: List all present deb packages
   shell: bash -c "ls *.deb"
     chdir={{repo_sources_path}}
+
+- name: Send files to aptly repository
+  shell: find . -name '*.deb' | xargs curl -X POST -F file=@{} http://10.10.10.62:8080/api/files/{}
+    chdir={{repo_sources_path}}

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -13,19 +13,19 @@
   register: deb_paths
 
 - name: Cleanup deb name first_path
-  shell: dpkg --info {{item.stdout}} | grep Package
+  shell: "dpkg --info {{item.stdout_lines}} | grep 'Package: '"
   with_items:
     - "{{ deb_paths }}"
   register: deb_names_first_path
 
 - name: Finish deb name cleanup
-  shell: echo {{ item.stdout.replace('Package ', '')}}
+  shell: echo {{ item.stdout_lines.replace('Package ', '')}}
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0.stdout }} http://10.10.10.62:8080/api/files/{{ item.1.stdout }}
+  shell: curl -X POST -F file=@{{ item.0.stdout_lines }} http://10.10.10.62:8080/api/files/{{ item.1.stdout_lines }}
   with_together:
     - "{{ deb_paths }}"
     - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -25,6 +25,7 @@
 
 - name: Send files to aptly repository
   shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
+    chdir={{repo_sources_path}}
   with_together:
-    - "{{ installed_packages_names_stdout_lines|default([]) }}"
     - "{{ deb_paths_stdout_lines|default([]) }}"
+    - "{{ installed_packages_names_stdout_lines|default([]) }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -2,5 +2,5 @@
 # Playbook for uploading deb files to an apt repo
 
 - name: List all present deb packages
-  shell: ls *.deb
-  chdir={{repo_sources_path}}
+  shell: bash -c "ls *.deb"
+    chdir={{repo_sources_path}}

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -23,9 +23,3 @@
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names
-
-- name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
-  with_together:
-    - "{{ deb_paths }}"
-    - "{{ deb_names }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,5 +6,7 @@
     chdir={{repo_sources_path}}
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@ros-indigo-sr-benchmarking_0.0.0-0trusty_amd64.deb http://10.10.10.62:8080/api/files/ros-indigo-sr-benchmarking
+  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/{{item}}
     chdir={{repo_sources_path}}
+  with_fileglob:
+    - {{repo_sources_path}}/*.deb

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,7 +6,7 @@
     chdir={{repo_sources_path}}
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/{{item}}
+  shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/{{item}}.split('/')[-1].split('_')[0]
     chdir={{repo_sources_path}}
   with_fileglob:
     - "{{repo_sources_path}}/*.deb"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,26 +6,25 @@
     chdir={{repo_sources_path}}
 
 - name: Save deb paths
-  shell: echo {{item}}
+  shell: bash -c "find . -name '*.deb' -print0
     chdir={{repo_sources_path}}
-  with_fileglob:
-    - "{{repo_sources_path}}/*.deb"
   register: deb_paths
 
-- name: Cleanup deb name first_path
-  shell: "dpkg --info {{item.results.stdout}} | grep 'Package: '"
-  with_items:
-    - "{{ deb_paths }}"
-  register: deb_names_first_path
+- name: Set variable to workaround ansible type evaluation issue
+  set_fact:
+    deb_paths_stdout_lines: "{{deb_paths.stdout_lines}}"
 
-- name: Finish deb name cleanup
-  shell: echo {{ item.results.stdout.replace('Package ', '')}}
-  with_items:
-    - "{{ deb_names_first_path }}"
-  register: deb_names
+- name: Cleanup names
+  shell: bash -c "find . -name '*.deb' -print0  | xargs -0 -I {} dpkg --info  {} | sed -n -e 's/^\s*Package:\s*//p'"
+    chdir={{repo_sources_path}}
+  register: installed_packages_names
+
+- name: Set variable to workaround ansible type evaluation issue
+  set_fact:
+    installed_packages_names_stdout_lines: "{{installed_packages_names.stdout_lines}}"
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0.results.stdout }} http://10.10.10.62:8080/api/files/{{ item.1.results.stdout }}
+  shell: curl -X POST -F file=@{{ item.0 }} http://10.10.10.62:8080/api/files/{{ item.1 }}
   with_together:
-    - "{{ deb_paths }}"
-    - "{{ deb_names }}"
+    - "{{ installed_packages_names_stdout_lines|default([]) }}"
+    - "{{ deb_paths_stdout_lines|default([]) }}"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -6,7 +6,7 @@
     chdir={{repo_sources_path}}
 
 - name: Save deb paths
-  shell: bash -c "find . -name '*.deb' -print0"
+  shell: bash -c "find . -name '*.deb'"
     chdir={{repo_sources_path}}
   register: deb_paths
 

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -19,7 +19,7 @@
   register: deb_names_first_path
 
 - name: Finish deb name cleanup
-  shell: echo {{ item.replace('Package: ', '')}}
+  shell: echo {{ item.replace('Package ', '')}}
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -13,7 +13,7 @@
   register: deb_paths
 
 - name: Cleanup deb name first_path
-  shell: bash -c "dpkg --info {{item}} | grep Package
+  shell: dpkg --info {{item}} | grep Package
   with_items:
     - "{{ deb_paths }}"
   register: deb_names_first_path

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -9,4 +9,4 @@
   shell: curl -X POST -F file=@{{item}} http://10.10.10.62:8080/api/files/{{item}}
     chdir={{repo_sources_path}}
   with_fileglob:
-    - {{repo_sources_path}}/*.deb
+    - "{{repo_sources_path}}/*.deb"

--- a/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
+++ b/ansible/roles/ci/deploy/upload_debs/tasks/main.yaml
@@ -13,19 +13,19 @@
   register: deb_paths
 
 - name: Cleanup deb name first_path
-  shell: "dpkg --info {{item.stdout_lines}} | grep 'Package: '"
+  shell: "dpkg --info {{item.results.stdout}} | grep 'Package: '"
   with_items:
     - "{{ deb_paths }}"
   register: deb_names_first_path
 
 - name: Finish deb name cleanup
-  shell: echo {{ item.stdout_lines.replace('Package ', '')}}
+  shell: echo {{ item.results.stdout.replace('Package ', '')}}
   with_items:
     - "{{ deb_names_first_path }}"
   register: deb_names
 
 - name: Send files to aptly repository
-  shell: curl -X POST -F file=@{{ item.0.stdout_lines }} http://10.10.10.62:8080/api/files/{{ item.1.stdout_lines }}
+  shell: curl -X POST -F file=@{{ item.0.results.stdout }} http://10.10.10.62:8080/api/files/{{ item.1.results.stdout }}
   with_together:
     - "{{ deb_paths }}"
     - "{{ deb_names }}"


### PR DESCRIPTION
There's some work to be done on the aptly side of things: once the file is uploaded we need to add / publish it on the aptly repo. 

We could change the default url to aptly (this one is pointing to my laptop's ip address on the vpn since I have a docker image deployed there for testing). It can probably be modified once we have an image setup at shadow?

This role is used [here](http://jenkins.shadow.local:8080/job/sr_benchmarking_debs/)