### PR TITLE
Kinetic CI

### DIFF
--- a/bin/sr-run-ci-build.sh
+++ b/bin/sr-run-ci-build.sh
@@ -6,8 +6,9 @@ set -e # fail on errors
 export toolset_branch=$1
 export server_type=$2
 export tags_list=$3
+export ros_release=${4:-"indigo"}
 
-export docker_image=${docker_image_name:-"shadowrobot/ubuntu-ros-indigo-build-tools"}
+export docker_image=${docker_image_name:-"shadowrobot/ubuntu-ros-${ros_release}-build-tools"}
 
 # Do not install all libraries for docker container CI servers
 if  [ "circle" != $server_type ] && [ "semaphore_docker" != $server_type ] && [ "local" != $server_type ] && [ "travis" != $server_type ]; then
@@ -75,7 +76,7 @@ case $server_type in
   ;;
 
 "docker_hub") echo "Docker Hub"
-  PYTHONUNBUFFERED=1 ansible-playbook -v -i "localhost," -c local docker_site.yml --tags "docker_hub,$tags_list"
+  PYTHONUNBUFFERED=1 ansible-playbook -v -i "localhost," -c local docker_site.yml --tags "docker_hub,$tags_list" --extra-vars "ros_release=${ros_release}"
   ;;
 
 "local") echo "Local run"

--- a/docker/ci/kinetic/ui/Dockerfile
+++ b/docker/ci/kinetic/ui/Dockerfile
@@ -1,0 +1,96 @@
+#
+# ROS Indigo with build tools Dockerfile
+#
+# https://github.com/shadow-robot/sr-build-tools/
+#
+
+FROM ros:kinetic-perception
+
+MAINTAINER "Shadow Robot's Software Team <software@shadowrobot.com>"
+
+LABEL Description="This image is used to make ROS Indigo based projects build faster using build tools" Vendor="Shadow Robot" Version="1.0"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV USERNAME user
+ENV PULSE_SERVER /run/pulse/native
+
+ENV GOSU_VERSION 1.10
+
+ENV toolset_branch="F_kinetic_ci"
+ENV server_type="docker_hub"
+ENV used_modules="check_cache,create_workspace"
+ENV remote_shell_script="https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh"
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN set -x && \
+
+    echo "Setting up bash as default shell" && \
+    rm /bin/sh && \
+    ln -s /bin/bash /bin/sh && \
+
+    echo "Setting locale" && \
+    locale-gen en_US.UTF-8 && \
+
+    echo "Installing curl" && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends ca-certificates wget && \
+
+    echo "Installing sudo" && \
+    apt-get install -y sudo && \
+
+    echo "Install gosudo" && \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" && \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true && \
+
+    echo "Intall some basic GUI and sound libs" && \
+    apt-get install -y \
+        xz-utils file locales dbus-x11 pulseaudio dmz-cursor-theme \
+        fonts-dejavu fonts-liberation hicolor-icon-theme \
+        libcanberra-gtk3-0 libcanberra-gtk-module libcanberra-gtk3-module \
+        libasound2 libgtk2.0-0 libdbus-glib-1-2 libxt6 libexif12 \
+        libgl1-mesa-glx libgl1-mesa-dri && \
+    update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
+
+    echo "Installing UI tools" && \
+    apt-get install -y \
+        terminator \
+        vim \
+        mc
+
+RUN echo "Adding user" && \
+    useradd -m $USERNAME && \
+    echo "$USERNAME:$USERNAME" | chpasswd && \
+    usermod --shell /bin/bash $USERNAME && \
+    usermod -aG sudo $USERNAME && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+
+    echo "Running one-liner" && \
+    wget -O /tmp/oneliner "$( echo "$remote_shell_script" | sed 's/#/%23/g' )" && \
+    chmod 755 /tmp/oneliner && \
+    gosu $USERNAME /tmp/oneliner "$toolset_branch" $server_type $used_modules && \
+
+    echo "Setup .bashrc for ROS" && \
+    echo "source /opt/ros/indigo/setup.bash" >> /home/$USERNAME/.bashrc && \
+    #Fix for qt and X server errors
+    echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc && \
+    # cd to home on login
+    echo "cd" >> /home/$USERNAME/.bashrc && \
+
+    echo "Removing cache" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/usr/bin/terminator"]

--- a/docker/ci/kinetic/ui/Dockerfile
+++ b/docker/ci/kinetic/ui/Dockerfile
@@ -17,7 +17,7 @@ ENV PULSE_SERVER /run/pulse/native
 
 ENV GOSU_VERSION 1.10
 
-ENV toolset_branch="F_kinetic_ci"
+ENV toolset_branch="F_some_docker_refactoring"
 ENV server_type="docker_hub"
 ENV used_modules="check_cache,create_workspace"
 ENV remote_shell_script="https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh"

--- a/docker/ci/kinetic/ui/Dockerfile
+++ b/docker/ci/kinetic/ui/Dockerfile
@@ -21,6 +21,7 @@ ENV toolset_branch="F_kinetic_ci"
 ENV server_type="docker_hub"
 ENV used_modules="check_cache,create_workspace"
 ENV remote_shell_script="https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh"
+ENV ros_release="kinetic"
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
@@ -65,9 +66,9 @@ RUN set -x && \
     apt-get install -y \
         terminator \
         vim \
-        mc
+        mc && \
 
-RUN echo "Adding user" && \
+    echo "Adding user" && \
     useradd -m $USERNAME && \
     echo "$USERNAME:$USERNAME" | chpasswd && \
     usermod --shell /bin/bash $USERNAME && \
@@ -78,7 +79,7 @@ RUN echo "Adding user" && \
     echo "Running one-liner" && \
     wget -O /tmp/oneliner "$( echo "$remote_shell_script" | sed 's/#/%23/g' )" && \
     chmod 755 /tmp/oneliner && \
-    gosu $USERNAME /tmp/oneliner "$toolset_branch" $server_type $used_modules && \
+    gosu $USERNAME /tmp/oneliner "$toolset_branch" $server_type $used_modules $ros_release && \
 
     echo "Setup .bashrc for ROS" && \
     echo "source /opt/ros/indigo/setup.bash" >> /home/$USERNAME/.bashrc && \

--- a/docker/ci/kinetic/ui/entrypoint.sh
+++ b/docker/ci/kinetic/ui/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_ID=${LOCAL_USER_ID:-9001}
+
+usermod  --uid $USER_ID $USERNAME
+groupmod --gid $USER_ID $USERNAME
+
+export HOME=/home/$USERNAME
+
+exec /usr/local/bin/gosu $USERNAME "$@"


### PR DESCRIPTION
I have modified the CI build script (bin/sr-run-ci-build.sh) to take an optional 4th parameter, specifying the ROS release to install. Defaults to Indigo so as not to break existing uses.

I've also added a Dockerfile that successfully builds a Kinetic CI image.

I tested both Indigo and Kinetic docker builds/script runs. As committed, this will fail until merged, as I've changed the toolset_branch parameter in the Dockerfile back to F_some_docker_refactoring, rather than leaving it as F_kinetic_ci and fixing it after the merge.