### PR TITLE
Kinetic CI

### DIFF
--- a/bin/sr-run-ci-build.sh
+++ b/bin/sr-run-ci-build.sh
@@ -6,8 +6,9 @@ set -e # fail on errors
 export toolset_branch=$1
 export server_type=$2
 export tags_list=$3
+export ros_release=${4:-"indigo"}
 
-export docker_image=${docker_image_name:-"shadowrobot/ubuntu-ros-indigo-build-tools"}
+export docker_image=${docker_image_name:-"shadowrobot/ubuntu-ros-${ros_release}-build-tools"}
 
 # Do not install all libraries for docker container CI servers
 if  [ "circle" != $server_type ] && [ "semaphore_docker" != $server_type ] && [ "local" != $server_type ] && [ "travis" != $server_type ]; then
@@ -75,7 +76,7 @@ case $server_type in
   ;;
 
 "docker_hub") echo "Docker Hub"
-  sudo PYTHONUNBUFFERED=1 ansible-playbook -v -i "localhost," -c local docker_site.yml --tags "docker_hub,$tags_list"
+  sudo PYTHONUNBUFFERED=1 ansible-playbook -v -i "localhost," -c local docker_site.yml --tags "docker_hub,$tags_list" --extra-vars "ros_release=${ros_release}"
   ;;
 
 "local") echo "Local run"

--- a/docker/ci/kinetic/base/Dockerfile
+++ b/docker/ci/kinetic/base/Dockerfile
@@ -1,0 +1,36 @@
+#
+# ROS Indigo with build tools Dockerfile
+#
+# https://github.com/shadow-robot/sr-build-tools/
+#
+
+FROM ros:kinetic
+
+MAINTAINER "Shadow Robot's Software Team <software@shadowrobot.com>"
+
+LABEL Description="This image is used to make ROS Indigo based projects build faster using build tools" Vendor="Shadow Robot" Version="1.0"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV toolset_branch="master"
+ENV server_type="docker_hub"
+ENV used_modules="check_cache,create_workspace"
+ENV remote_shell_script="https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh"
+ENV ros_release="kinetic"
+
+RUN echo "Setting up bash as default shell" && \
+    rm /bin/sh && \
+    ln -s /bin/bash /bin/sh && \
+    echo "Setting locale" && \
+    locale-gen en_US.UTF-8 && \
+    echo "Installing curl" && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install curl -y && \
+    echo "Installing sudo" && \
+    apt-get install sudo -y && \
+    echo "Running one-liner" && \
+    (curl -s "$( echo "$remote_shell_script" | sed 's/#/%23/g' )" | bash /dev/stdin "$toolset_branch" $server_type $used_modules $ros_release) && \
+    echo "Removing cache" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
I have modified the CI build script (bin/sr-run-ci-build.sh) to take an optional 4th parameter, specifying the ROS release to install. Defaults to Indigo so as not to break existing uses.

I've also added a Dockerfile that successfully builds a Kinetic CI image.

I tested both Indigo and Kinetic docker builds/script runs. As committed, this will fail until merged, as I've changed the toolset_branch parameter in the Dockerfile back to master, rather than leaving it as F_kinetic_ci and fixing it after the merge.