### PR TITLE
Fixed kinetic-intel docker file order of lines

### DIFF
--- a/docker/shadow-hand/kinetic/intel_ide/Dockerfile
+++ b/docker/shadow-hand/kinetic/intel_ide/Dockerfile
@@ -1,6 +1,6 @@
-LABEL Description="This ROS Kinetic image contains Shadow's dexterous hand software with build tools. It includes IDE environments. Intel compatible" Vendor="Shadow Robot" Version="1.0"
-
 FROM shadowrobot/dexterous-hand:kinetic
+
+LABEL Description="This ROS Kinetic image contains Shadow's dexterous hand software with build tools. It includes IDE environments. Intel compatible" Vendor="Shadow Robot" Version="1.0"
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
the jenkins doesnt compile (was compiling locally) when the label is the first line so I move it after the FROM