### PR TITLE
Fixing repository.rosinstall newline vulnerability

### DIFF
--- a/ansible/roles/ci/update_dependencies/files/load_repositories.sh
+++ b/ansible/roles/ci/update_dependencies/files/load_repositories.sh
@@ -13,7 +13,8 @@ export previous_repo_count=0
 export loops_count=10
 
 while [ $current_repo_count -ne $previous_repo_count ]; do
-  find . -type f -name $rosintall_filename -exec sed '$a\#' {} \; | sed -e "s/{{github_login}}/$github_user/g" | sed -e "s/{{github_password}}/$github_password/g" | wstool merge -a -y -
+  find . -type f -name $rosintall_filename -exec wstool merge -y {} \;
+  sed -i "s/{{github_login}}/$github_user/g; s/{{github_password}}/$github_password/g" .rosinstall
   wstool update --delete-changed-uris
 
   export previous_repo_count=$current_repo_count


### PR DESCRIPTION
Previously, if a repository.rosinstall did not finish with a newline, the next repository's first source dependency was ignored.