### PR TITLE
add support for lint_result_dir variable to local server type

### DIFF
--- a/ansible/roles/ci/code_style_check/cpp/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/cpp/tasks/main.yml
@@ -2,7 +2,7 @@
 # Playbook for C++ code style check
 
 - name: Find C++ h and cpp files in each package
-  shell: find -type f \( -name "*.h" -o -name "*.cpp" \) -printf "%p "
+  shell: find -type f \( -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) -printf "%p "
     chdir={{repo_sources_path}}/{{item.path}}
   with_items: "{{repo_packages_list|default([])}}"
   register: repo_packages_and_h_cpp_files
@@ -12,27 +12,8 @@
     repo_packages_and_h_cpp_files_results: "{{repo_packages_and_h_cpp_files.results}}"
 
 - name: Execute roslint for every package and write results in unit tests format
-  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && rosrun roslint test_wrapper {{ros_workspace}}/build/test_results/{{item.item.name}}/roslint-h-cpp-{{item.item.name}}.xml 'rosrun roslint cpplint --filter=-runtime/references {{item.stdout}}' "
+  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && rosrun roslint cpplint --extensions=hpp,cpp,h --filter=-runtime/references {{item.stdout}} &> \"{{lint_result_dir}}/{{item.item.name}}/roslint-h-cpp-{{item.item.name}}.cpplint\""
     chdir={{repo_sources_path}}/{{item.item.path}}
   with_items: "{{repo_packages_and_h_cpp_files_results|default([])}}"
   when: item.stdout != ""
-  ignore_errors: True
-
-- name: Find C++ hpp files in each package (this is done due to a of such file currently in source code. In future those file would be removed)
-  shell: find -type f -name "*.hpp" -printf "%p\n"
-    chdir={{repo_sources_path}}/{{item.path}}
-  with_items: "{{repo_packages_list|default([])}}"
-  register: repo_packages_and_hpp_files
-
-- name: Set variable to workaround ansible type evaluation issue
-  set_fact:
-    repo_packages_and_hpp_files_results: "{{repo_packages_and_hpp_files.results}}"
-
-- name: Execute roslint for every package and write results in unit tests format. In order to skip hpp files extension validation using stdin feed to checker.
-  shell: bash -c 'source /opt/ros/{{ros_release}}/setup.bash && rosrun roslint test_wrapper {{ros_workspace}}/build/test_results/{{item.0.item.name}}/roslint-hpp-{{item.1|basename}}.xml "eval cat {{item.1}} | rosrun roslint cpplint --filter=-runtime/references -" '
-    chdir={{repo_sources_path}}/{{item.0.item.path}}
-  with_subelements:
-     - "{{repo_packages_and_hpp_files_results|default([])}}"
-     - stdout_lines
-  when: item.0.stdout != ""
   ignore_errors: True

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -22,14 +22,14 @@
     python_files_without_extension_results: "{{python_files_without_extension.results}}"
 
 - name: Execute roslint for every package and .py files and write results in unit tests format
-  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && rosrun roslint test_wrapper {{ros_workspace}}/build/test_results/{{item.item.name}}/roslint-python-py-{{item.item.name}}.xml 'rosrun roslint pep8 --max-line-length=120 {{item.stdout}}' "
+  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && mkdir -p \"{{lint_result_dir}}/{{item.item.name}}\" && rosrun roslint pep8 --format=pylint --max-line-length=120 {{item.stdout}} > \"{{lint_result_dir}}/{{item.item.name}}/roslint-python-py-{{item.item.name}}.pylint\""
     chdir={{repo_sources_path}}/{{item.item.path}}
   with_items: "{{python_files_with_extension_results|default([])}}"
   when: item.stdout != ""
   ignore_errors: True
 
 - name: Execute roslint for every package and no extension files and write results in unit tests format
-  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && rosrun roslint test_wrapper {{ros_workspace}}/build/test_results/{{item.item.name}}/roslint-python-ex-{{item.item.name}}.xml 'rosrun roslint pep8 --max-line-length=120 {{item.stdout}}' "
+  shell: bash -c "source /opt/ros/{{ros_release}}/setup.bash && mkdir -p \"{{lint_result_dir}}/{{item.item.name}}\" && rosrun roslint pep8 --format=pylint --max-line-length=120 {{item.stdout}} > \"{{lint_result_dir}}/{{item.item.name}}/roslint-python-ex-{{item.item.name}}.pylint\""
     chdir={{repo_sources_path}}/{{item.item.path}}
   with_items: "{{python_files_without_extension_results|default([])}}"
   when: item.stdout != ""

--- a/ansible/roles/ci/doc/setup/jenkins.md
+++ b/ansible/roles/ci/doc/setup/jenkins.md
@@ -54,6 +54,7 @@ Follow these steps to setup Jenkins job
   
   export unit_tests_result_dir="$relative_job_path/unit_tests"
   export coverage_tests_result_dir="$relative_job_path/code_coverage"
+  export lint_result_dir="$relative_job_path/lint_results"
   
   export remote_shell_script="https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh"
   curl -s "$( echo "$remote_shell_script" | sed 's/#/%23/g' )" | bash /dev/stdin "$toolset_branch" $server_type $used_modules $relative_job_path

--- a/ansible/roles/ci/servers/local/init/tasks/main.yml
+++ b/ansible/roles/ci/servers/local/init/tasks/main.yml
@@ -13,6 +13,10 @@
   fail: msg="Variable local_code_coverage_dir was not set by CI server"
   when: local_code_coverage_dir is not defined
 
+- name: check if local_lint_result_dir variable was set by build server
+  fail: msg="Variable local_lint_result_dir was not set by CI server"
+  when: local_lint_result_dir is not defined
+
 - name: check if local_benchmarking_dir variable was set by build server
   fail: msg="Variable local_benchmarking_dir was not set by CI server"
   when: local_benchmarking_dir is not defined
@@ -53,21 +57,31 @@
   set_fact:
     code_coverage_results_dir: "{{local_code_coverage_dir}}"
 
+- name: Set lint_result_dir
+  set_fact:
+    lint_result_dir: "{{local_lint_result_dir}}"
+
 - name: Set benchmarking_results_dir
   set_fact:
     benchmarking_results_dir: "{{local_benchmarking_dir}}"
 
+- name: Clean test results directory in case of failure during cache build
+  shell: bash -c "rm -rf {{test_results_dir}}"
+
 - name: Create tests directory
   file: state=directory path={{test_results_dir}}
 
-- name: Clean tests results directory in case of failure during cache build
-  shell: bash -c "rm -rf {{test_results_dir}}/*"
+- name: Clean coverage results directory in case of failure during cached build
+  shell: bash -c "rm -rf {{code_coverage_results_dir}}"
 
 - name: Create coverage directory
   file: state=directory path={{code_coverage_results_dir}}
 
-- name: Clean coverage results directory in case of failure during cached build
-  shell: bash -c "rm -rf {{code_coverage_results_dir}}/*"
+- name: Clean lint result directory in case of failure during cached build
+  shell: bash -c "rm -rf {{lint_result_dir}}"
+
+- name: Create lint directory
+  file: state=directory path={{lint_result_dir}}
 
 - name: Create benchmarking directory
   file: state=directory path={{benchmarking_results_dir}}

--- a/bin/sr-run-ci-build.sh
+++ b/bin/sr-run-ci-build.sh
@@ -100,6 +100,12 @@ case $server_type in
   else
     export coverage_tests_dir="/host/"$coverage_tests_result_dir
   fi
+  if [ -z "$lint_result_dir" ]
+  then
+    export lint_result_dir="$docker_user_home/workspace/lint_results"
+  else
+    export lint_result_dir="/host/"$lint_result_dir
+  fi
   if [ -z "$benchmarking_result_dir" ]
   then
     export benchmarking_dir="$docker_user_home/workspace/benchmarking_results"
@@ -118,7 +124,7 @@ case $server_type in
     fi
   done
 
-  export extra_variables="$extra_variables local_repo_dir=/host$local_repo_dir local_test_dir=$unit_tests_dir local_code_coverage_dir=$coverage_tests_dir"
+  export extra_variables="$extra_variables local_repo_dir=/host$local_repo_dir local_test_dir=$unit_tests_dir local_code_coverage_dir=$coverage_tests_dir local_lint_result_dir=$lint_result_dir local_deb_dir=$deb_dir"
   export extra_variables="$extra_variables local_benchmarking_dir=$benchmarking_dir"
   docker run -w "$docker_user_home/sr-build-tools/ansible" -e LOCAL_USER_ID=$(id -u) $docker_flags --rm -v $HOME:/host:rw $docker_image  bash -c "git pull && git checkout $toolset_branch && git pull && PYTHONUNBUFFERED=1 ansible-playbook -v -i \"localhost,\" -c local docker_site.yml --tags \"local,$tags_list\" -e \"$extra_variables\" "
   ;;


### PR DESCRIPTION
this puts the lint results (in pylint / cpplint format) in a place where CI plugins can find and visualize them

I'm not familiar enough to know where else a variable like this would need to be introduced - if you tell me, I'll gladly add it to all other roles where it's needed :)

Also, I realize that it might be desirable to make it optional to maintain compatibility with existing setups. Again, if you would prefer that, just let me know and I'll make that change