### PR TITLE
Adding sr_visualization_common to kinetic source dependencies.

### DIFF
--- a/data/shadow_robot-kinetic.rosinstall
+++ b/data/shadow_robot-kinetic.rosinstall
@@ -77,3 +77,8 @@
     local-name: optoforce
     uri: https://github.com/shadow-robot/optoforce.git
     version: indigo-devel
+
+- git:
+    local-name: sr_visualization_common
+    uri: https://github.com/shadow-robot/sr_visualization_common
+    version: kinetic-devel


### PR DESCRIPTION
The one-liner shadow kinetic install was failing due to the kinetic rosinstall not having been updated with the new main shadow repo, sr_visualization_common. This fixes it.