### PR TITLE
Hand E desktop icons, gazebo model pre-population

### DIFF
--- a/ansible/files/gazebo/models/ground_plane/model-1_2.sdf
+++ b/ansible/files/gazebo/models/ground_plane/model-1_2.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<gazebo version="1.2">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>100</mu>
+              <mu2>50</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <cast_shadows>false</cast_shadows>
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</gazebo>

--- a/ansible/files/gazebo/models/ground_plane/model-1_3.sdf
+++ b/ansible/files/gazebo/models/ground_plane/model-1_3.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<sdf version="1.3">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>100</mu>
+              <mu2>50</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <cast_shadows>false</cast_shadows>
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/ansible/files/gazebo/models/ground_plane/model-1_4.sdf
+++ b/ansible/files/gazebo/models/ground_plane/model-1_4.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<sdf version="1.4">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>100</mu>
+              <mu2>50</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <cast_shadows>false</cast_shadows>
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/ansible/files/gazebo/models/ground_plane/model.config
+++ b/ansible/files/gazebo/models/ground_plane/model.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Ground Plane</name>
+  <version>1.0</version>
+  <sdf version="1.2">model-1_2.sdf</sdf>
+  <sdf version="1.3">model-1_3.sdf</sdf>
+  <sdf version="1.4">model-1_4.sdf</sdf>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A simple ground plane.
+  </description>
+</model>

--- a/ansible/files/gazebo/models/ground_plane/model.sdf
+++ b/ansible/files/gazebo/models/ground_plane/model.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>100</mu>
+              <mu2>50</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <cast_shadows>false</cast_shadows>
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/ansible/files/gazebo/models/sun/model-1_2.sdf
+++ b/ansible/files/gazebo/models/sun/model-1_2.sdf
@@ -1,0 +1,19 @@
+<gazebo version='1.2'>
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+
+    <pose>0 0 10 0 0 0</pose>
+    <diffuse>0.8 0.8 0.8 1</diffuse>
+    <specular>0.1 0.1 0.1 1</specular>
+
+    <attenuation>
+      <range>1000</range>
+      <constant>0.9</constant>
+      <linear>0.01</linear>
+      <quadratic>0.001</quadratic>
+    </attenuation>
+
+    <direction>-0.5 0.5 -1.0</direction>
+  </light>
+</gazebo>

--- a/ansible/files/gazebo/models/sun/model-1_3.sdf
+++ b/ansible/files/gazebo/models/sun/model-1_3.sdf
@@ -1,0 +1,19 @@
+<sdf version='1.3'>
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+
+    <pose>0 0 10 0 0 0</pose>
+    <diffuse>0.8 0.8 0.8 1</diffuse>
+    <specular>0.1 0.1 0.1 1</specular>
+
+    <attenuation>
+      <range>1000</range>
+      <constant>0.9</constant>
+      <linear>0.01</linear>
+      <quadratic>0.001</quadratic>
+    </attenuation>
+
+    <direction>-0.5 0.5 -1.0</direction>
+  </light>
+</sdf>

--- a/ansible/files/gazebo/models/sun/model-1_4.sdf
+++ b/ansible/files/gazebo/models/sun/model-1_4.sdf
@@ -1,0 +1,20 @@
+<?xml version='1.0'?>
+<sdf version='1.4'>
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+
+    <pose>0 0 10 0 0 0</pose>
+    <diffuse>0.8 0.8 0.8 1</diffuse>
+    <specular>0.2 0.2 0.2 1</specular>
+
+    <attenuation>
+      <range>1000</range>
+      <constant>0.9</constant>
+      <linear>0.01</linear>
+      <quadratic>0.001</quadratic>
+    </attenuation>
+
+    <direction>-0.5 0.1 -0.9</direction>
+  </light>
+</sdf>

--- a/ansible/files/gazebo/models/sun/model.config
+++ b/ansible/files/gazebo/models/sun/model.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Sun</name>
+  <version>1.0</version>
+  <sdf version="1.2">model-1_2.sdf</sdf>
+  <sdf version="1.3">model-1_3.sdf</sdf>
+  <sdf version="1.4">model-1_4.sdf</sdf>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A directional light for the sun.
+  </description>
+</model>

--- a/ansible/files/gazebo/models/sun/model.sdf
+++ b/ansible/files/gazebo/models/sun/model.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+    <pose>0 0 10 0 0 0</pose>
+    <diffuse>0.8 0.8 0.8 1</diffuse>
+    <specular>0.2 0.2 0.2 1</specular>
+    <attenuation>
+      <range>1000</range>
+      <constant>0.9</constant>
+      <linear>0.01</linear>
+      <quadratic>0.001</quadratic>
+    </attenuation>
+    <direction>-0.5 0.1 -0.9</direction>
+  </light>
+</sdf>

--- a/ansible/files/home/icons_kinetic/Desktop/Hand Sliders.desktop
+++ b/ansible/files/home/icons_kinetic/Desktop/Hand Sliders.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=bash -i -c 'rqt -s sr_gui_joint_slider.joint_slider.SrGuiJointSlider'
+Name=Hand Sliders
+Icon=/usr/local/share/icons/shadowrobot/gnome-nettool.svg
+StartupNotify=true

--- a/ansible/files/home/icons_kinetic/Desktop/Roscore.desktop
+++ b/ansible/files/home/icons_kinetic/Desktop/Roscore.desktop
@@ -1,0 +1,8 @@
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=xterm -hold -title "roscore" -e "bash -i -c roscore"
+Name=Roscore
+Icon=/opt/ros/kinetic/share/rqt_gui/resource/rqt.png

--- a/ansible/files/home/icons_kinetic/Desktop/Rviz.desktop
+++ b/ansible/files/home/icons_kinetic/Desktop/Rviz.desktop
@@ -1,0 +1,8 @@
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=xterm -hold -title "rviz" -e "bash -i -c 'rosrun rviz rviz'"
+Name=Rviz
+Icon=/opt/ros/kinetic/share/rviz/icons/package.png

--- a/ansible/files/home/icons_kinetic/Desktop/Start Hand.desktop
+++ b/ansible/files/home/icons_kinetic/Desktop/Start Hand.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=xterm -title "Hand Demo" -e bash -i -c 'roslaunch sr_hand  hand_demo_view.launch'
+Name=Start Hand
+Icon=/home/hand_demo/hydro_ws/src/sr_visualization/sr_visualization_icons/icons/iconHand.png

--- a/ansible/files/home/icons_kinetic/Desktop/Start Hand.desktop
+++ b/ansible/files/home/icons_kinetic/Desktop/Start Hand.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Type=Application
 Terminal=false
-Exec=xterm -title "Hand Demo" -e bash -i -c 'roslaunch sr_hand  hand_demo_view.launch'
+Exec=xterm -title "Hand Demo" -e bash -i -c 'roslaunch sr_robot_launch srhand.launch sim:=true'
 Name=Start Hand
 Icon=/home/hand_demo/hydro_ws/src/sr_visualization/sr_visualization_icons/icons/iconHand.png

--- a/ansible/files/icons/shadowrobot/gnome-nettool.svg
+++ b/ansible/files/icons/shadowrobot/gnome-nettool.svg
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/s odipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48px"
+   height="48px"
+   id="svg1307"
+   sodipodi:version="0.32"
+   inkscape:version="0.43"
+   sodipodi:docbase="/home/hbons/Desktop/Tango"
+   sodipodi:docname="gnome-network-utils.svg"
+   inkscape:export-filename="/home/hbons/Desktop/gnome-network-utils.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs1309">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2268">
+      <stop
+         style="stop-color:#5c3566;stop-opacity:1;"
+         offset="0"
+         id="stop2270" />
+      <stop
+         style="stop-color:#5c3566;stop-opacity:0;"
+         offset="1"
+         id="stop2272" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2260">
+      <stop
+         style="stop-color:#ad7fa8;stop-opacity:1;"
+         offset="0"
+         id="stop2262" />
+      <stop
+         style="stop-color:#ad7fa8;stop-opacity:0;"
+         offset="1"
+         id="stop2264" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2251">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop2253" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:0;"
+         offset="1"
+         id="stop2255" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2235">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop2237" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:0;"
+         offset="1"
+         id="stop2239" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4045">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop4047" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:0;"
+         offset="1"
+         id="stop4049" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4029">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4031" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4033" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2257">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2259" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0;"
+         offset="1"
+         id="stop2261" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2246">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2248" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0;"
+         offset="1"
+         id="stop2250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2211">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2213" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0;"
+         offset="1"
+         id="stop2215" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2211"
+       id="radialGradient2217"
+       cx="24.5"
+       cy="20.062737"
+       fx="24.5"
+       fy="20.062737"
+       r="17.46875"
+       gradientTransform="matrix(1.5194,6.959671e-18,-6.760444e-18,1.47591,-12.7253,-10.27302)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2246"
+       id="radialGradient2252"
+       cx="24.5"
+       cy="9.5105629"
+       fx="24.5"
+       fy="9.5105629"
+       r="14.439805"
+       gradientTransform="matrix(0.979268,6.031362e-17,-3.106849e-17,0.504433,0.50792,9.0591)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2257"
+       id="radialGradient2263"
+       cx="15.794439"
+       cy="8.3293562"
+       fx="15.794439"
+       fy="8.3293562"
+       r="14.5"
+       gradientTransform="matrix(2.449439,3.028846e-17,-1.514349e-17,1.2495,-26.68752,1.980857)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4029"
+       id="radialGradient4035"
+       cx="24.5"
+       cy="17.500086"
+       fx="24.5"
+       fy="17.500086"
+       r="14.50017"
+       gradientTransform="matrix(2.332907,1.036019e-15,-5.358713e-16,1.206675,-32.65621,-3.616833)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4045"
+       id="linearGradient4051"
+       x1="1.2813275"
+       y1="46.89257"
+       x2="23.978548"
+       y2="24.195351"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3.124994e-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2235"
+       id="linearGradient2241"
+       x1="21.507809"
+       y1="43.466747"
+       x2="21.507809"
+       y2="47.465462"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2251"
+       id="linearGradient2258"
+       x1="21.5"
+       y1="43.467159"
+       x2="21.5"
+       y2="47.532516"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2260"
+       id="linearGradient2266"
+       x1="28.58882"
+       y1="42.96125"
+       x2="28.58882"
+       y2="48.851078"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.779487,0,0,0.69777,6.215382,13.4756)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2268"
+       id="linearGradient2274"
+       x1="28.6952"
+       y1="43.444878"
+       x2="28.6952"
+       y2="47.467724"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.102382,0,0,1,-3.135271,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2251"
+       id="linearGradient2288"
+       gradientUnits="userSpaceOnUse"
+       x1="21.5"
+       y1="43.467159"
+       x2="21.5"
+       y2="47.532516"
+       gradientTransform="translate(0,-48)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2235"
+       id="linearGradient2290"
+       gradientUnits="userSpaceOnUse"
+       x1="21.507809"
+       y1="43.466747"
+       x2="21.507809"
+       y2="47.465462"
+       gradientTransform="translate(0,-48)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2260"
+       id="linearGradient2292"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.779487,0,0,0.69777,6.215382,-34.5244)"
+       x1="28.58882"
+       y1="42.96125"
+       x2="28.58882"
+       y2="48.851078" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2268"
+       id="linearGradient2294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.102382,0,0,1,-3.135271,-48)"
+       x1="28.6952"
+       y1="43.444878"
+       x2="28.6952"
+       y2="47.467724" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.004828"
+     inkscape:cx="40.088701"
+     inkscape:cy="25.470012"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1267"
+     inkscape:window-height="971"
+     inkscape:window-x="6"
+     inkscape:window-y="21"
+     fill="#888a85"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <metadata
+     id="metadata1312">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="opacity:1;fill:url(#linearGradient2288);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2280"
+       width="3"
+       height="6"
+       x="20"
+       y="-6"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2290);stroke-width:1.00000036;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2282"
+       width="3.9812489"
+       height="7.0079803"
+       x="19.517185"
+       y="-6.5044022"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient2292);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2284"
+       width="3"
+       height="5.566967"
+       x="27"
+       y="-5.566967"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2294);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2286"
+       width="3.9856846"
+       height="7.9782333"
+       x="26.504959"
+       y="-6.4782333"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient2258);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2340"
+       width="3"
+       height="6"
+       x="20"
+       y="42" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2241);stroke-width:1.00000036;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2346"
+       width="3.9812489"
+       height="7.0079803"
+       x="19.517185"
+       y="41.495598" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient2266);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2348"
+       width="3"
+       height="5.566967"
+       x="27"
+       y="42.433033" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2274);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2354"
+       width="3.9856846"
+       height="7.9782333"
+       x="26.504959"
+       y="41.521767" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.00000048;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2239"
+       width="6.1280832"
+       height="5"
+       x="25.434546"
+       y="37.53125"
+       rx="2.0714309"
+       ry="2.0714285" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.00000048;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2241"
+       width="6.1280832"
+       height="5"
+       x="18.371916"
+       y="37.53125"
+       rx="2.0714309"
+       ry="2.0714285" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.00000048;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2237"
+       width="6.1280832"
+       height="5"
+       x="25.5"
+       y="5.53125"
+       rx="2.0714309"
+       ry="2.0714285" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.00000048;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2235"
+       width="6.1280832"
+       height="5"
+       x="18.43737"
+       y="5.53125"
+       rx="2.0714309"
+       ry="2.0714285" />
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:1.00000024;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 9.5000017,7.5012726 L 39.499998,7.5012726 C 41.161999,7.5012726 42.5,8.7638627 42.5,10.332192 L 42.5,37.700341 C 42.5,39.268671 41.161999,40.531262 39.499998,40.531262 L 9.5000017,40.531262 C 7.8380007,40.531262 6.5,39.268671 6.5,37.700341 L 6.5,10.332192 C 6.5,8.7638627 7.8380007,7.5012726 9.5000017,7.5012726 z "
+       id="rect1315" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-1.0303071"
+       inkscape:original="M 9.5 7.5 C 7.837999 7.5 6.5 8.7754203 6.5 10.34375 L 6.5 37.6875 C 6.5 39.25583 7.8379988 40.531251 9.5 40.53125 L 39.5 40.53125 C 41.162001 40.53125 42.5 39.255831 42.5 37.6875 L 42.5 10.34375 C 42.5 8.7754207 41.162003 7.4999999 39.5 7.5 L 9.5 7.5 z "
+       xlink:href="#rect1315"
+       style="fill:url(#radialGradient2217);fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
+       id="path2209"
+       inkscape:href="#rect1315"
+       d="M 9.5,7.5 C 8.3651044,7.5 7.53125,8.3301653 7.53125,9.3125 L 7.53125,36.65625 C 7.53125,37.638585 8.3651048,38.468751 9.5,38.46875 L 39.5,38.46875 C 40.634896,38.46875 41.46875,37.638587 41.46875,36.65625 L 41.46875,9.3125 C 41.46875,8.3301645 40.634898,7.5 39.5,7.5 L 9.5,7.5 z " />
+    <path
+       style="fill:#fcaf3e;fill-opacity:1;fill-rule:evenodd;stroke:#ce5c00;stroke-width:1.00000107;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 10.571775,10.537961 L 38.428248,10.537961 C 39.021823,10.537961 39.499682,11.015821 39.499682,11.609396 L 39.499682,25.459629 C 39.499682,26.053204 39.021823,26.531064 38.428248,26.531064 L 10.571775,26.531064 C 9.9782004,26.531064 9.5003405,26.053204 9.5003405,25.459629 L 9.5003405,11.609396 C 9.5003405,11.015821 9.9782004,10.537961 10.571775,10.537961 z "
+       id="rect2190" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-0.99585479"
+       inkscape:original="M 10.5625 10.53125 C 9.9689254 10.53125 9.5 11.031425 9.5 11.625 L 9.5 25.46875 C 9.5 26.062325 9.968925 26.531251 10.5625 26.53125 L 38.4375 26.53125 C 39.031075 26.53125 39.499999 26.062325 39.5 25.46875 L 39.5 11.625 C 39.5 11.031425 39.031074 10.53125 38.4375 10.53125 L 10.5625 10.53125 z "
+       xlink:href="#rect2190"
+       style="opacity:0.5;fill:url(#radialGradient2252);fill-opacity:1;fill-rule:evenodd;stroke:url(#radialGradient4035);stroke-width:1.00000107;stroke-miterlimit:4;stroke-opacity:1"
+       id="path2244"
+       inkscape:href="#rect2190"
+       d="M 10.5625,10.5 C 10.528363,10.5 10.5,10.52466 10.5,10.59375 L 10.5,24.4375 C 10.5,24.506591 10.493411,24.5 10.5625,24.5 L 38.4375,24.5 C 38.506591,24.5 38.5,24.506593 38.5,24.4375 L 38.5,10.59375 C 38.5,10.52466 38.471636,10.5 38.4375,10.5 L 10.5625,10.5 z " />
+    <rect
+       style="opacity:1;fill:#d4d8d0;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999869;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2396"
+       width="1.9660958"
+       height="4.9999948"
+       x="45.847095"
+       y="9.9921741"
+       rx="0.9830479"
+       ry="0.9830479"
+       transform="matrix(0.866025,0.5,-0.5,0.866025,0,0)" />
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 38.56005,32.562599 C 38.56005,34.235817 37.202603,35.593791 35.530037,35.593791 C 33.857469,35.593791 32.500022,34.235817 32.500022,32.562599 C 32.500022,30.889382 33.857469,29.531408 35.530037,29.531408 C 37.202603,29.531408 38.56005,30.889382 38.56005,32.562599 z "
+       id="path2192" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-1.0485017"
+       inkscape:original="M 35.53125 29.53125 C 33.858682 29.53125 32.499999 30.889283 32.5 32.5625 C 32.5 34.235718 33.858682 35.593749 35.53125 35.59375 C 37.203816 35.59375 38.562499 34.235718 38.5625 32.5625 C 38.5625 30.889283 37.203816 29.53125 35.53125 29.53125 z "
+       xlink:href="#path2192"
+       style="opacity:0.6;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
+       id="path2267"
+       inkscape:href="#path2192"
+       d="M 35.53125,29.5625 C 34.426232,29.5625 33.562499,30.425635 33.5625,31.53125 C 33.5625,32.636867 34.426231,33.499999 35.53125,33.5 C 36.636265,33.5 37.499999,32.636867 37.5,31.53125 C 37.5,30.425635 36.636265,29.5625 35.53125,29.5625 z " />
+    <path
+       style="opacity:0.5;fill:url(#radialGradient2263);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 10,11.03125 L 39,11.03125 C 30.093039,19.938211 20.117581,15.913669 10,26.03125 C 10,22.647147 10,11.03125 10,11.03125 z "
+       id="rect2254"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="opacity:0.9;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13,14.03125 L 13,15.03125 L 13,17.03125 L 10,17.03125 L 10,18.03125 L 13,18.03125 L 14,18.03125 L 14,15.03125 L 15,15.03125 L 15,20.03125 L 15,21.03125 L 18,21.03125 L 18,20.03125 L 18,18.03125 L 20,18.03125 L 23,18.03125 L 24,18.03125 L 24,15.03125 L 25,15.03125 L 25,20.03125 L 25,21.03125 L 28,21.03125 L 28,20.03125 L 28,18.03125 L 30,18.03125 L 32,18.03125 L 33,18.03125 L 33,15.03125 L 34,15.03125 L 34,20.03125 L 34,21.03125 L 37,21.03125 L 37,20.03125 L 37,18.03125 L 39,18.03125 L 39,17.03125 L 36,17.03125 L 36,18.03125 L 36,20.03125 L 35,20.03125 L 35,15.03125 L 35,14.03125 L 32,14.03125 L 32,15.03125 L 32,17.03125 L 30,17.03125 L 27,17.03125 L 27,18.03125 L 27,20.03125 L 26,20.03125 L 26,15.03125 L 26,14.03125 L 23,14.03125 L 23,15.03125 L 23,17.03125 L 20,17.03125 L 17,17.03125 L 17,18.03125 L 17,20.03125 L 16,20.03125 L 16,15.03125 L 16,14.03125 L 13,14.03125 z "
+       id="rect2221" />
+    <rect
+       style="opacity:1;fill:#d4d8d0;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999869;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2394"
+       width="1.9660958"
+       height="4.9999948"
+       x="38.470245"
+       y="10.31988"
+       rx="0.9830479"
+       ry="0.9830479"
+       transform="matrix(0.866025,0.5,-0.5,0.866025,0,0)" />
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 29.560061,32.562599 C 29.560061,34.235817 28.202614,35.593791 26.530048,35.593791 C 24.85748,35.593791 23.500033,34.235817 23.500033,32.562599 C 23.500033,30.889382 24.85748,29.531408 26.530048,29.531408 C 28.202614,29.531408 29.560061,30.889382 29.560061,32.562599 z "
+       id="path2388" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-1.0485017"
+       inkscape:original="M 35.53125 29.53125 C 33.858682 29.53125 32.499999 30.889283 32.5 32.5625 C 32.5 34.235718 33.858682 35.593749 35.53125 35.59375 C 37.203816 35.59375 38.562499 34.235718 38.5625 32.5625 C 38.5625 30.889283 37.203816 29.53125 35.53125 29.53125 z "
+       xlink:href="#path2192"
+       style="opacity:0.6;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
+       id="path2390"
+       inkscape:href="#path2192"
+       d="M 35.53125,29.5625 C 34.426232,29.5625 33.562499,30.425635 33.5625,31.53125 C 33.5625,32.636867 34.426231,33.499999 35.53125,33.5 C 36.636265,33.5 37.499999,32.636867 37.5,31.53125 C 37.5,30.425635 36.636265,29.5625 35.53125,29.5625 z "
+       transform="translate(-8.999989,-5.960464e-8)" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3103"
+       width="1"
+       height="0.99999952"
+       x="36"
+       y="24.03125" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3105"
+       width="1"
+       height="2"
+       x="34"
+       y="23.03125" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3107"
+       width="1"
+       height="3.0000007"
+       x="32"
+       y="22.03125" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3109"
+       width="1"
+       height="2.000001"
+       x="30"
+       y="23.03125" />
+    <rect
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3111"
+       width="1"
+       height="1"
+       x="28"
+       y="24.03125" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4051);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 10,28.03125 L 10,29.03125 L 10,37.03125 L 10,38.03125 L 20,38.03125 L 20,37.03125 L 20,29.03125 L 20,28.03125 L 10,28.03125 z M 11,29.03125 L 13,29.03125 L 13,31.03125 L 11,31.03125 L 11,29.03125 z M 14,29.03125 L 16,29.03125 L 16,31.03125 L 14,31.03125 L 14,29.03125 z M 17,29.03125 L 19,29.03125 L 19,31.03125 L 17,31.03125 L 17,29.03125 z M 11,32.03125 L 13,32.03125 L 13,34.03125 L 11,34.03125 L 11,32.03125 z M 14,32.03125 L 16,32.03125 L 16,34.03125 L 14,34.03125 L 14,32.03125 z M 17,32.03125 L 19,32.03125 L 19,34.03125 L 17,34.03125 L 17,32.03125 z M 11,35.03125 L 13,35.03125 L 13,37.03125 L 11,37.03125 L 11,35.03125 z M 14,35.03125 L 16,35.03125 L 16,37.03125 L 14,37.03125 L 14,35.03125 z M 17,35.03125 L 19,35.03125 L 19,37.03125 L 17,37.03125 L 17,35.03125 z "
+       id="rect3988" />
+  </g>
+</svg>

--- a/ansible/roles/dev_machine/meta/main.yml
+++ b/ansible/roles/dev_machine/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - { role: ros_install, sudo: yes }
   - { role: ros_workspace }
+  - { role: gazebo_models }

--- a/ansible/roles/gazebo_models/defaults/main.yaml
+++ b/ansible/roles/gazebo_models/defaults/main.yaml
@@ -1,0 +1,2 @@
+ros_user: "handuser"
+ros_group: "{{ros_user}}"

--- a/ansible/roles/gazebo_models/tasks/main.yaml
+++ b/ansible/roles/gazebo_models/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: Install basic gazebo models necessary for successful first run
+  copy: src="files/gazebo/models" dest="~{{ros_user}}/.gazebo" owner={{ros_user}} group={{ros_group}}

--- a/ansible/roles/hand_e_icons/defaults/main.yml
+++ b/ansible/roles/hand_e_icons/defaults/main.yml
@@ -1,0 +1,4 @@
+ros_user: handuser
+ros_group: handuser
+ros_user_home_files: files/home/icons_kinetic
+ros_workspace: /home/handuser/workspace/shadow_robot-kinetic/base

--- a/ansible/roles/hand_e_icons/defaults/main.yml
+++ b/ansible/roles/hand_e_icons/defaults/main.yml
@@ -1,4 +1,4 @@
-ros_user: handuser
-ros_group: handuser
-ros_user_home_files: files/home/icons_kinetic
-ros_workspace: /home/handuser/workspace/shadow_robot-kinetic/base
+ros_user: "handuser"
+ros_group: "{{ros_user}}"
+ros_user_home_files: "files/home/icons_kinetic"
+ros_workspace: "/home/{{ros_user}}/workspace/shadow_robot-kinetic/base"

--- a/ansible/roles/hand_e_icons/tasks/main.yml
+++ b/ansible/roles/hand_e_icons/tasks/main.yml
@@ -1,13 +1,13 @@
 - name: Copy icons to /usr/local/share/icons
   copy: src="files/icons" dest="/usr/local/share"
-  sudo: yes
-  sudo_user: "{{ros_user}}"
+  become: yes
+  become_user: "{{ros_user}}"
 
 - name: Install home directory files from {{ros_user_home_files}}
   copy: src="{{ros_user_home_files}}/" dest="~{{ros_user}}/" owner={{ros_user}} group={{ros_group}}
   when: ros_user_home_files|default("") != ""
-  sudo: yes
-  sudo_user: "{{ros_user}}"
+  become: yes
+  become_user: "{{ros_user}}"
 
 - name: Fix desktop icon path
   replace:
@@ -23,6 +23,6 @@
   
 - name: Set executable bit for icons
   shell: "find ~{{ros_user}}/Desktop/*.desktop -exec chmod +x {} +"
-  sudo: yes
-  sudo_user: "{{ros_user}}"
+  become: yes
+  become_user: "{{ros_user}}"
   

--- a/ansible/roles/hand_e_icons/tasks/main.yml
+++ b/ansible/roles/hand_e_icons/tasks/main.yml
@@ -9,11 +9,17 @@
   sudo: yes
   sudo_user: "{{ros_user}}"
 
-- name: Fix desktop icon paths
+- name: Fix desktop icon path
   replace:
     dest: "~{{ros_user}}/Desktop/Start Hand.desktop"
     regexp: '/home/hand_demo/hydro_ws'
     replace: "{{ros_workspace}}"
+
+- name: Make desktop icon path absolute
+  replace:
+    dest: "~{{ros_user}}/Desktop/Start Hand.desktop"
+    regexp: "~{{ros_user}}"
+    replace: "/home/{{ros_user}}"
   
 - name: Set executable bit for icons
   shell: "find ~{{ros_user}}/Desktop/*.desktop -exec chmod +x {} +"

--- a/ansible/roles/hand_e_icons/tasks/main.yml
+++ b/ansible/roles/hand_e_icons/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Copy icons to /usr/local/share/icons
+  copy: src="files/icons" dest="/usr/local/share"
+  sudo: yes
+  sudo_user: "{{ros_user}}"
+
+- name: Install home directory files from {{ros_user_home_files}}
+  copy: src="{{ros_user_home_files}}/" dest="~{{ros_user}}/" owner={{ros_user}} group={{ros_group}}
+  when: ros_user_home_files|default("") != ""
+  sudo: yes
+  sudo_user: "{{ros_user}}"
+
+- name: Fix desktop icon paths
+  replace:
+    dest: "~{{ros_user}}/Desktop/Start Hand.desktop"
+    regexp: '/home/hand_demo/hydro_ws'
+    replace: "{{ros_workspace}}"
+  
+- name: Set executable bit for icons
+  shell: "find ~{{ros_user}}/Desktop/*.desktop -exec chmod +x {} +"
+  sudo: yes
+  sudo_user: "{{ros_user}}"
+  

--- a/ansible/vagrant_site.yml
+++ b/ansible/vagrant_site.yml
@@ -182,3 +182,4 @@
     - {role: dev_machine, tags: ["default","mongodb"]}
     - {role: mongo_database, tags: ["mongodb"]}
     - {role: pyassimp, tags: ["pyassimp"]}
+    - {role: hand_e_icons, tags: ["hand_e_icons"]}


### PR DESCRIPTION
This PR does three things:
* Fixes bug [#SRC-1544](https://shadowrobot.atlassian.net/browse/SRC-1544) by adding an ansible role that installs Hand E desktop icons
* Adds an ansible role that pre-populates Gazebo's models directory, to avoid the Gazebo start-up bug. This new role is a dependency of `dev-machine`, meaning all new images etc. will have the fix
* Changes the Hand E desktop icon to use a more recent, working launch method in kinetic