### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/ros/kinetic/eigen_3.3.7/Dockerfile
+++ b/docker/ros/kinetic/eigen_3.3.7/Dockerfile
@@ -8,10 +8,10 @@ ENV aurora_script="https://raw.githubusercontent.com/shadow-robot/aurora/$aurora
 RUN set +x && \
     apt-get update && \
     echo "Installing Eigen library v. 3.3.7" && \
-    wget "http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2" -O $eigen_folder.tar.bz2 && \
+    wget "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2" -O $eigen_folder.tar.bz2 && \
     mkdir $eigen_folder && \
     tar -xjf $eigen_folder.tar.bz2 -C $eigen_folder --strip-components=1 && \
-    cd eigen_3.3.7 && \
+    cd $eigen_folder && \
     mkdir build && \
     cd build && \
     cmake .. && \


### PR DESCRIPTION
Bit bucket no longer serves this file. 

In fact, 3.3.7 is now the default version, but let's keep this image in case for now.