### PR TITLE
Fixing repositories clone depth level to 1

### DIFF
--- a/ansible/roles/ros_workspace/files/load_repositories.sh
+++ b/ansible/roles/ros_workspace/files/load_repositories.sh
@@ -19,6 +19,27 @@ recursive_rosinstall () {
     done
 }
 
+recursive_rosinstall_shallow () {
+    while [ $current_repo_count -ne $previous_repo_count ]; do
+        find $current_folder -type f -name $rosinstall_filename -exec wstool merge -y {} \;
+        sed -i "$1" .rosinstall
+
+        mv .rosinstall repository.rosinstall
+  	wstool init --shallow . repository.rosinstall -j5
+
+        export previous_repo_count=$current_repo_count
+        export current_repo_count=$(find $destination_folder -type f -name $rosinstall_filename | wc -l)
+
+        if [ $loops_count -ge 1 ]; then
+            export loops_count=$((loops_count - 1))
+        else
+            break
+        fi
+        export current_folder=$destination_folder
+    done
+}
+
+
 export initial_folder=$1
 export destination_folder=$2
 export levels_depth=$3
@@ -38,7 +59,7 @@ export previous_repo_count=-1
 export loops_count=$((levels_depth - 1))
 
 if [ "${use_ssh_uri}" = true ]; then
-    recursive_rosinstall "/https/s/\//:/3; s/https:\/\/{{github_login}}:{{github_password}}/git/g; s/https:\/\//git@/g"
+    recursive_rosinstall_shallow "/https/s/\//:/3; s/https:\/\/{{github_login}}:{{github_password}}/git/g; s/https:\/\//git@/g"
 else
-    recursive_rosinstall "s/{{github_login}}/$github_user/g; s/{{github_password}}/$github_password/g"
+    recursive_rosinstall_shallow "s/{{github_login}}/$github_user/g; s/{{github_password}}/$github_password/g"
 fi

--- a/ansible/roles/ros_workspace/files/load_repositories.sh
+++ b/ansible/roles/ros_workspace/files/load_repositories.sh
@@ -3,29 +3,11 @@ set -e # fail on errors
 
 recursive_rosinstall () {
     while [ $current_repo_count -ne $previous_repo_count ]; do
-        find $current_folder -type f -name $rosinstall_filename -exec wstool merge -y {} \; 
-        sed -i "$1" .rosinstall
-        wstool update --abort-changed-uris  -j5
-
-        export previous_repo_count=$current_repo_count
-        export current_repo_count=$(find $destination_folder -type f -name $rosinstall_filename | wc -l)
-
-        if [ $loops_count -ge 1 ]; then
-            export loops_count=$((loops_count - 1))
-        else
-            break
-        fi
-        export current_folder=$destination_folder
-    done
-}
-
-recursive_rosinstall_shallow () {
-    while [ $current_repo_count -ne $previous_repo_count ]; do
         find $current_folder -type f -name $rosinstall_filename -exec wstool merge -y {} \;
         sed -i "$1" .rosinstall
 
         mv .rosinstall repository.rosinstall
-  	wstool init --shallow . repository.rosinstall -j5
+       	wstool init --shallow . repository.rosinstall -j5
 
         export previous_repo_count=$current_repo_count
         export current_repo_count=$(find $destination_folder -type f -name $rosinstall_filename | wc -l)
@@ -59,7 +41,7 @@ export previous_repo_count=-1
 export loops_count=$((levels_depth - 1))
 
 if [ "${use_ssh_uri}" = true ]; then
-    recursive_rosinstall_shallow "/https/s/\//:/3; s/https:\/\/{{github_login}}:{{github_password}}/git/g; s/https:\/\//git@/g"
+    recursive_rosinstall "/https/s/\//:/3; s/https:\/\/{{github_login}}:{{github_password}}/git/g; s/https:\/\//git@/g"
 else
-    recursive_rosinstall_shallow "s/{{github_login}}/$github_user/g; s/{{github_password}}/$github_password/g"
+    recursive_rosinstall "s/{{github_login}}/$github_user/g; s/{{github_password}}/$github_password/g"
 fi

--- a/ansible/roles/ros_workspace/files/load_repositories.sh
+++ b/ansible/roles/ros_workspace/files/load_repositories.sh
@@ -7,7 +7,7 @@ recursive_rosinstall () {
         sed -i "$1" .rosinstall
 
         mv .rosinstall repository.rosinstall
-       	wstool init --shallow . repository.rosinstall -j5
+        wstool init --shallow . repository.rosinstall -j5
 
         export previous_repo_count=$current_repo_count
         export current_repo_count=$(find $destination_folder -type f -name $rosinstall_filename | wc -l)
@@ -20,7 +20,6 @@ recursive_rosinstall () {
         export current_folder=$destination_folder
     done
 }
-
 
 export initial_folder=$1
 export destination_folder=$2


### PR DESCRIPTION
## Proposed changes

User Story: https://shadowrobot.atlassian.net/browse/SRC-6034
Fixing load_repositories.sh to clone repos with depth 1.
This reduced the size of the image (both on DockerHub and pulled) by 260MB.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [X] Manually tested that added code works as intended (if any functional/runnable code is added).
- [X] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [X] Tested on real hardware (if the changed or added code is used with the real hardware).
- [X] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
