### PR TITLE
Src 4961 fix hpp linter

### DIFF
--- a/ansible/roles/ci/code_style_check/cpp/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/cpp/tasks/main.yml
@@ -61,7 +61,7 @@
   shell: 'source /opt/ros/{{ros_release}}/setup.bash && \
     rosrun roslint test_wrapper \
       {{ros_workspace}}/build/test_results/{{item.0.item.name}}/roslint-hpp-{{item.1|basename}}.xml \
-      "rosrun roslint cpplint --linelength=120 --filter=-runtime/references {{item.1}}" '
+      "rosrun roslint cpplint --extensions=hpp --linelength=120 --filter=-runtime/references {{item.1}}" '
   args:
     executable: "/bin/bash"
     chdir: "{{repo_sources_path}}/{{item.0.item.path}}"


### PR DESCRIPTION
## Proposed changes

I added a new parameter for where we preform linter checks on hpp files which fixes them not being checked.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [X] Manually tested that added code works as intended (if any functional/runnable code is added).
- [ ] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [ ] Tested on real hardware (if the changed or added code is used with the real hardware).
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
