### PR TITLE
Fixed issue where XML linter could not parse more then 1 file at a time.

### DIFF
--- a/ansible/roles/ci/code_style_check/xml/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/xml/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 # Playbook for XML code style check
 
-- name: Get list of all XML files in repository (any file with a line starting with < is assumed to be an XML file)
-  script: "../../common_resources/files/files_by_content_and_policy.sh \
-    {{repo_sources_path}} {{repo_sources_path}}/{{item.path}} '^<.*' .lintignore '.*\\.dox|.*\\.cpp|.*\\.html|.*\\.md'"
-  with_items: "{{repo_packages_list|default([])}}"
-  register: xml_files
-
-- name: Set variable to workaround ansible type evaluation issue
-  set_fact:
-    xml_files_results: "{{xml_files.results}}"
-
 - name: Execute xmllint for every package and all files with a line starting with < (assumed to be XML) and write results in unit tests format
-  script: ../files/ament_xmllint.py --xunit-file {{ros_workspace}}/build/test_results/{{item.item.name}}/ament-xmllint-ex-{{item.item.name}}.xml {{item.stdout}}
-  with_items: "{{xml_files_results|default([])}}"
-  when: item.stdout != ""
+  shell: ../files/ament_xmllint.py --xunit-file {{ros_workspace}}/build/test_results/{{repo_sources_path}}/ament-xmllint-ex-{{repo_sources_path}}.xml --path {{repo_sources_path}}
   ignore_errors: True

--- a/ansible/roles/ci/code_style_check/xml/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/xml/tasks/main.yml
@@ -2,5 +2,7 @@
 # Playbook for XML code style check
 
 - name: Execute xmllint for every package and all files with a line starting with < (assumed to be XML) and write results in unit tests format
-  shell: ../files/ament_xmllint.py --xunit-file {{ros_workspace}}/build/test_results/{{repo_sources_path}}/ament-xmllint-ex-{{repo_sources_path}}.xml --path {{repo_sources_path}}
+  script: ../files/ament_xmllint.py --xunit-file {{ros_workspace}}/build/test_results/{{repo_sources_path}}/ament-xmllint-ex-{{repo_sources_path}}.xml --path {{repo_sources_path}}
+  args:
+    executable: python3
   ignore_errors: True


### PR DESCRIPTION
Signed-off-by: Ben Starmer-Smith <ben@shadowrobot.com>

## Proposed changes

The current XML checks for our code_style CI/CD tests where not working. They would only preform the check on the first file passed into the test, I solved this solution by gathering the files through python, instead of passing them as a command line argument. I also added the ability to check xacro and launch files through the XML linter as they can be parsed as xml files.

Added a debug parameter for local testing.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
