### PR TITLE
Add EEpromtool to images

### DIFF
--- a/ansible/roles/ci/init/install/tasks/main.yml
+++ b/ansible/roles/ci/init/install/tasks/main.yml
@@ -22,6 +22,41 @@
   become_method: sudo
   become_user: root
 
+- name: Create shadow_tools folder
+  file:
+    path: "{{ansible_env.HOME}}/.shadow_tools"
+    state: directory
+    mode: '0755'
+  become: yes
+
+- name: Change ownership of shadow_tools folder
+  ansible.builtin.file:
+    path: "{{ansible_env.HOME}}/.shadow_tools"
+    state: directory
+    owner: user
+    group: user
+  become: yes
+
+- name: Copy EEpromtool
+  get_url:
+    url: https://github.com/shadow-robot/sr-build-tools/raw/master/bin/eepromtool
+    dest : "{{ansible_env.HOME}}/.shadow_tools/eepromtool"
+    mode: u+rwx
+  become: yes
+
+- name: Change EEpromtool ownership and group
+  file:
+    path: "{{ansible_env.HOME}}/.shadow_tools/eepromtool"
+    owner: user
+    group: user
+  become: yes
+
+- name: Write note about EEpromtool
+  copy:
+    dest: "{{ansible_env.HOME}}/.shadow_tools/eepromtool_readme"
+    content: |
+        Please Note that this tool should only be used by Shadow Support Staff and could lead to issues if used incorrectly.
+
 - name: Install ros1 packages
   apt: 
     name: ['ros-{{ros_release}}-cmake-modules']


### PR DESCRIPTION
## Proposed changes

Add EEpromtool to images. Will be added to the build-tool image which all other images are built on. Includes customer warnining not to use the tool unless with a shadow support engineer.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
