### PR TITLE
Removed deprecated kwarg

### DIFF
--- a/ansible/callback_plugins/log_beautifier.py
+++ b/ansible/callback_plugins/log_beautifier.py
@@ -15,7 +15,7 @@ def obfuscate_credentials(input_value):
 
 def fixed_dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
     json_message = self._original_dump_results(result, indent, sort_keys, keep_invocation)
-    message_dictionary = json.loads(json_message, encoding="utf-8")
+    message_dictionary = json.loads(json_message)
     result = ""
     for key, value in message_dictionary.items():
         if key not in ["stderr", "stdout_lines"]:


### PR DESCRIPTION
## Proposed changes

The kwarg "encoding" in `json.loads()` has been deprecated since python 3.1 and was fully removed in python 3.9 (See [change log](https://github.com/python/cpython/issues/83558)). This led to issues when trying to run our one-liner on python 3.10.

The kwarg has been removed, which should not cause any issues as `json.loads()` automatically detects the encoding with the kwarg having been ignored since py 3.1

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
