### PR TITLE
Added pycodestyle back to linter

### DIFF
--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -29,8 +29,13 @@
     src: ../files/pylintrc
     dest: /tmp/pylintrc
 
-- name: Execute pylint for every package and no extension files and write results in unit tests format
+- name: Execute pycodestyle and pylint for every package and no extension files and write results in unit tests format
   shell: |
+    source /opt/ros/{{ros_release}}/setup.bash && \
+    bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
+    {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
+    "pycodestyle --max-line-length=120 {{item}}"
+    
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
     {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -38,7 +38,7 @@
     
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
-    {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
+    {{ros_workspace}}/build/test_results/{{item}}/pylint-python3-ex-{{item}}.xml \
     "pylint -sn --rcfile=/tmp/pylintrc --msg-template='{abspath}:{line}:{column}:{msg_id}:{msg}' {{item}}"
   args:
     executable: "/bin/bash"

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -29,13 +29,13 @@
     src: ../files/pylintrc
     dest: /tmp/pylintrc
 
-# We ignore E203 in pycodestyle as the check is not PEP 8 compliant and causes conflicts with PEP 8 auto-formatters
+# We ignore E203, W503 in pycodestyle as the check is not PEP 8 compliant and causes conflicts with PEP 8 auto-formatters
 - name: Execute pycodestyle and pylint for every package and no extension files and write results in unit tests format
   shell: |
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
     {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
-    "pycodestyle --max-line-length=120 --ignore=E203 {{item}}"
+    "pycodestyle --max-line-length=120 --ignore=E203,W503 {{item}}"
     
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -35,7 +35,7 @@
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
     {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
-    "pycodestyle --max-line-length=120 --ignore=E203 {{item}}"
+    "pycodestyle --max-line-length=120 --extend-ignore=E203 {{item}}"
     
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -35,7 +35,7 @@
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
     {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
-    "pycodestyle --max-line-length=120 --extend-ignore=E203 {{item}}"
+    "pycodestyle --max-line-length=120 --ignore=E203 {{item}}"
     
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \

--- a/ansible/roles/ci/code_style_check/python/tasks/main.yml
+++ b/ansible/roles/ci/code_style_check/python/tasks/main.yml
@@ -29,12 +29,13 @@
     src: ../files/pylintrc
     dest: /tmp/pylintrc
 
+# We ignore E203 in pycodestyle as the check is not PEP 8 compliant and causes conflicts with PEP 8 auto-formatters
 - name: Execute pycodestyle and pylint for every package and no extension files and write results in unit tests format
   shell: |
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \
     {{ros_workspace}}/build/test_results/{{item}}/pylint-python-ex-{{item}}.xml \
-    "pycodestyle --max-line-length=120 {{item}}"
+    "pycodestyle --max-line-length=120 --ignore=E203 {{item}}"
     
     source /opt/ros/{{ros_release}}/setup.bash && \
     bash <(curl -Ls https://raw.githubusercontent.com/ros/roslint/refs/heads/master/scripts/test_wrapper) \

--- a/ansible/roles/ci/init/install/tasks/main.yml
+++ b/ansible/roles/ci/init/install/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Install PIP modules
   pip:
-    name: ['catkin_pkg','empy==3.3.2','coverage==6.5','catkin-lint','pylint==2.10.2','pycodestyle']
+    name: ['catkin_pkg','empy==3.3.2','coverage==6.5','catkin-lint','pylint==2.10.2']
     extra_args: '--upgrade'
     executable: pip3
   become: yes

--- a/ansible/roles/ci/init/install/tasks/main.yml
+++ b/ansible/roles/ci/init/install/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Install PIP modules
   pip:
-    name: ['catkin_pkg','empy','coverage','catkin-lint','pylint']
+    name: ['catkin_pkg','empy','coverage','catkin-lint','pylint','pycodestyle']
     extra_args: '--upgrade'
     executable: pip3
   become: yes
@@ -46,7 +46,7 @@
 
 - name: Install PIP modules
   pip:
-    name: ['catkin_pkg','empy==3.3.2','coverage==6.5','catkin-lint','pylint==2.10.2']
+    name: ['catkin_pkg','empy==3.3.2','coverage==6.5','catkin-lint','pylint==2.10.2','pycodestyle']
     extra_args: '--upgrade'
     executable: pip3
   become: yes


### PR DESCRIPTION
## Proposed changes

Pycodestyle was never added to the py 3.10 linter branch when it was created. Adding it now as it improves linting alongside PyLint and provides the same amount of linting coverage as we have in our py 3.8 branch.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
