### PR TITLE
Install pycodestyle in ros2 images

### DIFF
--- a/ansible/roles/ci/init/install/tasks/main.yml
+++ b/ansible/roles/ci/init/install/tasks/main.yml
@@ -21,9 +21,10 @@
 # Using a specific version for empy as that's the one that is installed by default in Ubuntu Jammy from debian repos
 # so pip will skip it. Otherwise pip throws an error when failing to uninstall the deb version to install the latest pip version.
 # I don't really know what this package is needed for.
+# We also install pycodestyle, since the roslint package (which comes with pycodestyle) is not supported for ros2
 - name: Install PIP modules
   pip: 
-    name: ['catkin_pkg','empy==3.3.4','coverage','catkin-lint','pylint']
+    name: ['catkin_pkg','empy==3.3.4','coverage','catkin-lint','pylint', 'pycodestyle']
     extra_args: '--upgrade'
     executable: pip3
   become: yes


### PR DESCRIPTION
## Proposed changes

In ros1 images we use roslint for linting, this installs pycodestyle automatically. Roslint is not supported in ros2 so we have to do all the linting ourselves, hence the need to install pycodestyle.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
