### PR TITLE
Fix ansible pip install task

### DIFF
--- a/ansible/roles/ci/init/install/tasks/main.yml
+++ b/ansible/roles/ci/init/install/tasks/main.yml
@@ -34,19 +34,18 @@
 
 - name: Install PIP modules
   pip:
-    name: ['catkin_pkg','empy','coverage','catkin-lint','pylint','pycodestyle','cpplint']
+    name: ['catkin_pkg','coverage','catkin-lint','pylint','pycodestyle','cpplint']
     extra_args: '--upgrade'
     executable: pip3
   become: yes
   become_method: sudo
   become_user: root
   when:
-    - ros_release == 'rolling'
-    - ros_release == 'humble'
+    - ros_release == 'rolling' or ros_release == 'humble'
 
 - name: Install PIP modules
   pip:
-    name: ['catkin_pkg','empy==3.3.2','coverage==6.5','catkin-lint','pylint==2.10.2', 'cpplint']
+    name: ['catkin_pkg','coverage==6.5','catkin-lint','pylint==2.10.2', 'cpplint']
     extra_args: '--upgrade'
     executable: pip3
   become: yes


### PR DESCRIPTION
Neither of the 'Install PIP modules' tasks were running previously because the 'when' conditions are AND by default.
Fixing this also uncovered a second issue, where pip is unable to upgrade the empy module because it was previously installed using apt.

If it is important to ensure empy==3.3.2 for the (not humble or rolling) case, we can add an extra task to remove empy via apt before running the pip install step (see below), but having tested this it looks like it removes loads of ros packages during the empy removal, I guess the ones which depend on empy.

`- name: Remove empy installed by apt
  apt:
    name: empy
    state: absent
  become: yes`

## Proposed changes

Please explain the changes you made. Add pictures or videos to explain them better if appropriate.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
